### PR TITLE
Quito autenticacion getAll y getById para: provincias, localidades y …

### DIFF
--- a/src/modules/localidades/localidades.controller.ts
+++ b/src/modules/localidades/localidades.controller.ts
@@ -107,10 +107,10 @@ export class LocalidadesController {
       totalPages: 4,
     },
   })
-  @ApiBearerAuth('JWT-auth')
-  @ApiSecurity('Auth0')
-  @Roles(Role.Admin)
-  @UseGuards(CompositeAuthGuard, RolesGuard)
+  // @ApiBearerAuth('JWT-auth')
+  // @ApiSecurity('Auth0')
+  // @Roles(Role.Admin)
+  // @UseGuards(CompositeAuthGuard, RolesGuard)
   @Get()
   findAll(@Query('page') page: number = 1, @Query('limit') limit: number = 5) {
     return this.localidadesService.findAll(page, limit);
@@ -131,10 +131,10 @@ export class LocalidadesController {
       },
     },
   })
-  @ApiBearerAuth('JWT-auth')
-  @ApiSecurity('Auth0')
-  @Roles(Role.Admin)
-  @UseGuards(CompositeAuthGuard, RolesGuard)
+  // @ApiBearerAuth('JWT-auth')
+  // @ApiSecurity('Auth0')
+  // @Roles(Role.Admin)
+  // @UseGuards(CompositeAuthGuard, RolesGuard)
   @Get(':id')
   findOne(@Param('id', ParseUUIDPipe) id: string) {
     return this.localidadesService.findOne(id);

--- a/src/modules/provincias/provincias.controller.ts
+++ b/src/modules/provincias/provincias.controller.ts
@@ -40,20 +40,20 @@ export class ProvinciasController {
 
   @Get()
   @ApiOperation({ summary: 'Retorna todas las provincias' })
-  @ApiBearerAuth('JWT-auth')
-  @ApiSecurity('Auth0')
-  @Roles(Role.Admin)
-  @UseGuards(CompositeAuthGuard, RolesGuard)
+  // @ApiBearerAuth('JWT-auth')
+  // @ApiSecurity('Auth0')
+  // @Roles(Role.Admin)
+  // @UseGuards(CompositeAuthGuard, RolesGuard)
   async findAll() {
     return this.provinciasService.findAll();
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Retorna 1 provincia  por id' })
-  @ApiBearerAuth('JWT-auth')
-  @ApiSecurity('Auth0')
-  @Roles(Role.Admin)
-  @UseGuards(CompositeAuthGuard, RolesGuard)
+  // @ApiBearerAuth('JWT-auth')
+  // @ApiSecurity('Auth0')
+  // @Roles(Role.Admin)
+  // @UseGuards(CompositeAuthGuard, RolesGuard)
   @UsePipes(new ValidationPipe({ transform: true }))
   async findOne(@Param('id') id: string) {
     return this.provinciasService.findOne(id);

--- a/src/modules/servicios/servicios.controller.ts
+++ b/src/modules/servicios/servicios.controller.ts
@@ -3,7 +3,6 @@ import {
   Get,
   Post,
   Body,
-  Patch,
   Param,
   Delete,
   HttpCode,
@@ -19,7 +18,6 @@ import {
 } from '@nestjs/common';
 import { ServiciosService } from './servicios.service';
 import { CreateServicioDto } from './dto/create-servicio.dto';
-import { UpdateServicioDto } from './dto/update-servicio.dto';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -71,10 +69,10 @@ export class ServiciosController {
 
   @Get()
   @ApiOperation({ summary: 'Ver todos los servicios' })
-  @ApiBearerAuth('JWT-auth')
-  @ApiSecurity('Auth0')
-  @Roles(Role.Admin)
-  @UseGuards(CompositeAuthGuard, RolesGuard)
+  // @ApiBearerAuth('JWT-auth')
+  // @ApiSecurity('Auth0')
+  // @Roles(Role.Admin)
+  // @UseGuards(CompositeAuthGuard, RolesGuard)
   @ApiQuery({
     name: 'page',
     required: false,
@@ -100,10 +98,10 @@ export class ServiciosController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Ver un servicio por :id' })
-  @ApiBearerAuth('JWT-auth')
-  @ApiSecurity('Auth0')
-  @Roles(Role.Admin)
-  @UseGuards(CompositeAuthGuard, RolesGuard)
+  // @ApiBearerAuth('JWT-auth')
+  // @ApiSecurity('Auth0')
+  // @Roles(Role.Admin)
+  // @UseGuards(CompositeAuthGuard, RolesGuard)
   @UsePipes(new ValidationPipe({ transform: true }))
   async findOne(@Param('id', new ParseUUIDPipe()) id: string) {
     const servicio = await this.serviciosService.findOne(id);


### PR DESCRIPTION
Desactivo autenticación getAll y getById para: provincias, localidades y servicios.
Necesario para el front, ya que el cliente al pedir el servicio desde la web, no podría hacerlo ya que no es usuario admin y tampoco usuario guest.