### PR TITLE
chores: equipos entity y equipos service

### DIFF
--- a/src/config/typeorm.ts
+++ b/src/config/typeorm.ts
@@ -12,7 +12,7 @@ const config = {
   username: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
   autoLoadEntities: true,
-  synchronize: true,
+  synchronize: false,
   extra: {
     timezone: 'America/Buenos_Aires', // Establecer la zona horaria aquí
   },

--- a/src/migrations/1723775479091-equiposuniquemac.ts
+++ b/src/migrations/1723775479091-equiposuniquemac.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Equiposuniquemac1723775479091 implements MigrationInterface {
+    name = 'Equiposuniquemac1723775479091'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "equipos" ADD CONSTRAINT "UQ_9110d5ef2d8422536a6cbbe933f" UNIQUE ("macEquipo")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "equipos" DROP CONSTRAINT "UQ_9110d5ef2d8422536a6cbbe933f"`);
+    }
+
+}

--- a/src/modules/equipos/entities/equipo.entity.ts
+++ b/src/modules/equipos/entities/equipo.entity.ts
@@ -41,7 +41,7 @@ export class Equipo {
   @Column({ nullable: true })
   cableMts: string;
 
-  @Column({ nullable: false })
+  @Column({ nullable: false, unique:true })
   macEquipo: string;
 
   @Column({ nullable: true })

--- a/src/modules/equipos/equipos.service.ts
+++ b/src/modules/equipos/equipos.service.ts
@@ -9,6 +9,7 @@ import { CreateEquipoDto } from './dto/create-equipo.dto';
 import { Equipo } from './entities/equipo.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
+import { UpdateEquipoDto } from './dto/update-equipo.dto';
 
 @Injectable()
 export class EquiposService {
@@ -91,15 +92,22 @@ export class EquiposService {
     }
   }
 
-  async update(id: string, updatedEquipoData: Partial<Equipo>) {
+  async update(id: string, updatedEquipoData: UpdateEquipoDto) {
     const oldEquipo = await this.equiposRepository.findOneBy({ id: id });
 
     if (!oldEquipo) {
       throw new NotFoundException(`Equipo con ID ${id} no encontrado`);
-    }
+    } 
 
     // Merge de datos: copiar las propiedades actualizadas
     Object.assign(oldEquipo, updatedEquipoData);
+
+    // busca el usuario por id 
+    const user = await this.usersRepository.findOneBy({id:updatedEquipoData.userId})
+    if(!user) throw new NotFoundException('Usuario no encontrado');
+
+    //asigna el usuario > el objeto entero para la relacion
+    oldEquipo.user = user;
 
     const updatedEquipo = await this.equiposRepository.save(oldEquipo);
     return updatedEquipo;


### PR DESCRIPTION
#macEquipos pasa a ser unique:true  
-si bien en el post/equipos hay un condicional para evitar duplicados, el put/equipos  permitia darle la misma mac a cualquier equipo.
#equipos service agrega al objecto user para hacer la relacion 
-si el userId (opcional) llega desde el dto, el servicio busca el usuario (el objecto) y lo asigna al equipo. 